### PR TITLE
mention pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ tags and indentation errors:
 
 ## Usage
 
-Install it with `pip install jinjalint`, then run it with:
+Install it with `pip install jinjalint` (or `pip3 install jinjalint` if you are using Python v.3.x), then run it with:
 
 ```sh
 $ jinjalint template-directory/


### PR DESCRIPTION
It's probably an elementary thing but I couldn't install this application because my `$ python` was MacOS Python, which is v2.x and this application requires Python v3.x. Now, `pip` is v2.x Python application; to install using Python v.3.x you must call `pip3`.