### PR TITLE
Add https://pre-commit.com integration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: jinjalint
+    name: jinjalint
+    description: A linter which checks the indentation and the correctness of Jinja-like/HTML templates.
+    language: python
+    language_version: python3
+    entry: jinjalint
+    types: [jinja]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ $ jinjalint some-file.html some-other-file.html
 
 This is a work in progress. Feel free to contribute :upside_down_face:
 
+
+## Usage with [pre-commit](https://pre-commit.com) git hooks framework
+
+Add to your `.pre-commit-config.yaml`:
+
+```yaml
+-   repo: https://github.com/motet-a/jinjalint
+    rev: ''  # select a tag / sha to point at
+    hooks:
+    -   id: jinjalint
+```
+
+Make sure to fill in the `rev` with a valid revision.
+
+_Note_: by default this configuration will only match `.jinja` and `.jinja2`
+files.  To match by regex pattern instead, override `types` and `files` as
+follows:
+
+```yaml
+    -   id: jinjalint
+        types: [file]  # restore the default `types` matching
+        files: \.(html|sls)$
+```
+
 ## Hacking
 
 Jinjalint is powered by [Parsy][parsy]. Parsy is an extremely powerful


### PR DESCRIPTION
Here's me trying it out with `pre-commit try-repo`

```console
$ pre-commit  try-repo ../jinjalint/
[INFO] Initializing environment for ../jinjalint/.
===============================================================================
Using config:
===============================================================================
repos:
-   repo: ../jinjalint/
    rev: 81fcb87c3ccfad0052f4e9567008d4867d4b4f2b
    hooks:
    -   id: jinjalint
===============================================================================
[INFO] Installing environment for ../jinjalint/.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
jinjalint................................................................Failed
hookid: jinjalint

test.jinja:2:0: Parse error: expected one of '%}', '-', 'any character' at 1:0

```

EDIT: oh oops, should have checked the issues before making this.  Looks like this resolves #13!