### PR TITLE
Document available config options and CLI flags (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ $ jinjalint some-file.html some-other-file.html
 
 This is a work in progress. Feel free to contribute :upside_down_face:
 
+
+### CLI flags
+
+#### `--verbose`
+
+Turns on verbose mode. This makes it easier to troubleshoot what configuration is used, and what files are being linted.
+
+```sh
+$ jinjalint --verbose template-directory/
+```
+
+#### `--parse-only`
+
+Don’t lint, check for syntax errors and exit.
+
+```sh
+$ jinjalint --parse-only template-directory/
+```
+
 ### Configuration
 
 Jinjalint supports defining a config file with the flag `--config`. Here is an [example config](./example_config.py) file with the available options:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,31 @@ $ jinjalint some-file.html some-other-file.html
 
 This is a work in progress. Feel free to contribute :upside_down_face:
 
+### Configuration
+
+Jinjalint supports defining a config file with the flag `--config`. Here is an [example config](./example_config.py) file with the available options:
+
+```python
+# Specify additional Jinja elements which can wrap HTML here. You
+# don't neet to specify simple elements which can't wrap anything like
+# {% extends %} or {% include %}.
+# Default: [].
+jinja_custom_elements_names = [
+    ('cache', 'endcache'),
+    ('captureas', 'endcaptureas'),
+    # ('for', 'else', 'empty', 'endfor'),
+]
+
+# How many spaces to use when checking indentation.
+# Default: 4
+indent_size = 4
+```
+
+This config file can then be used with:
+
+```sh
+$ jinjalint --config example_config.py template-directory/
+```
 
 ## Usage with [pre-commit](https://pre-commit.com) git hooks framework
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Jinjalint supports defining a config file with the flag `--config`. Here is an [
 
 ```python
 # Specify additional Jinja elements which can wrap HTML here. You
-# don't neet to specify simple elements which can't wrap anything like
+# don't need to specify simple elements which can't wrap anything like
 # {% extends %} or {% include %}.
 # Default: [].
 jinja_custom_elements_names = [


### PR DESCRIPTION
Related to #1. This documents the available config options and CLI flags. There aren't many of either, but this will make it that much faster for people looking into this linter to start using it.